### PR TITLE
fix: ensure API client preserves default headers

### DIFF
--- a/web/src/data/shared/__tests__/api.spec.ts
+++ b/web/src/data/shared/__tests__/api.spec.ts
@@ -1,4 +1,4 @@
-import { api, API_BASE_URL } from '../api'
+import { api, API_BASE_URL, apiRequest } from '../api'
 
 // Mock fetch globally
 global.fetch = jest.fn()
@@ -84,6 +84,29 @@ describe('API Base', () => {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
         })
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should merge custom headers with default content type', async () => {
+      const mockResponse = { data: 'test' }
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      const result = await apiRequest('/test', {
+        headers: { Authorization: 'Bearer token' },
+      })
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_BASE_URL}/test`,
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer token',
+          },
+        }),
       )
       expect(result).toEqual(mockResponse)
     })

--- a/web/src/data/shared/api.ts
+++ b/web/src/data/shared/api.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod'
-
 /**
  * Base URL for the backend API.
  * Points to the local development server.
@@ -16,18 +14,18 @@ export const API_BASE_URL = 'http://localhost:5005/api'
  * @returns {Promise<T>} The parsed response data
  * @throws {Error} When the request fails or returns an error status
  */
-async function apiRequest<T>(
+export async function apiRequest<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`
-  
+
   const config: RequestInit = {
+    ...options,
     headers: {
       'Content-Type': 'application/json',
-      ...options.headers,
+      ...(options.headers as Record<string, string>),
     },
-    ...options,
   }
 
   try {


### PR DESCRIPTION
## Summary
- correctly merge custom headers in API client while preserving default content-type
- add regression test for header merging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689658e09d78832bbdf32b59ca07c285